### PR TITLE
Guest photo upload file selection issue

### DIFF
--- a/script.js
+++ b/script.js
@@ -242,7 +242,7 @@ class VIPService {
             addGuestBtn.addEventListener('click', () => this.showAddGuestModal());
         }
         if (addGuestForm) {
-            addGuestForm.addEventListener('click', (e) => this.handleAddGuest(e));
+            addGuestForm.addEventListener('submit', (e) => this.handleAddGuest(e));
         }
         
         // Çıkış


### PR DESCRIPTION
Change `addGuestForm` event listener from `click` to `submit`.

The `click` listener on the form was preventing the default action of the file input, which stopped the file chooser from opening. Changing it to `submit` allows the file chooser to function correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8b099ba-671d-4143-965e-7e0f75a548f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d8b099ba-671d-4143-965e-7e0f75a548f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

