### PR TITLE
Guest photo update button unresponsive

### DIFF
--- a/script.js
+++ b/script.js
@@ -720,7 +720,12 @@ class VIPService {
 
         if (isEditMode && editGuestId) {
             console.log('🔍 Misafir güncelleniyor:', { guestId: editGuestId, name, guestClass });
-            await this.handleUpdateGuest(e, editGuestId);
+            try {
+                await this.handleUpdateGuest(e, editGuestId);
+            } finally {
+                // Edit modunda erken dönüş öncesi submit flag'ini sıfırla
+                this.isSubmitting = false;
+            }
             return;
         }
 
@@ -1027,7 +1032,7 @@ class VIPService {
         if (modal) {
             const title = modal.querySelector('h2');
             const form = document.getElementById('addGuestForm');
-            const saveBtn = form.querySelector('.save-btn');
+            const saveBtn = form.querySelector('.submit-btn');
 
             if (title) title.textContent = 'Yeni Misafir Ekle';
             if (saveBtn) saveBtn.textContent = 'Kaydet';


### PR DESCRIPTION
Fix unresponsive guest update button by resetting `isSubmitting` and correcting button selector.

The update button was unresponsive when editing guest information with a photo because the `isSubmitting` flag was not reset in the edit branch of `handleAddGuest`, preventing subsequent submissions. Additionally, the button selector for UI reset was incorrect.

---
<a href="https://cursor.com/background-agent?bcId=bc-769a01e3-18ae-4786-a559-449603b7407a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-769a01e3-18ae-4786-a559-449603b7407a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

