### PR TITLE
Misafir pazarlama bilgisi görünmeme hatasını düzelt

### DIFF
--- a/init-postgresql.js
+++ b/init-postgresql.js
@@ -41,6 +41,7 @@ async function initDatabase() {
                 cigar VARCHAR(100),
                 special_requests TEXT,
                 other_info TEXT,
+                marketing_info TEXT,
                 photo_path VARCHAR(255),
                 created_by INTEGER REFERENCES users(id),
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/server.js
+++ b/server.js
@@ -82,6 +82,13 @@ async function createTables() {
         `);
         console.log('✅ Events tablosu oluşturuldu.');
         
+        // guests.marketing_info kolonunu garanti altına al
+        await pool.query(`
+            ALTER TABLE guests 
+            ADD COLUMN IF NOT EXISTS marketing_info TEXT
+        `);
+        console.log('✅ guests.marketing_info kolonu kontrol edildi/eklendi.');
+        
         // Örnek veriler ekle (devre dışı)
         // await addSampleData();
         


### PR DESCRIPTION
Add `marketing_info` column to the `guests` table to fix an issue where marketing data was not being saved or displayed.

The `guests.marketing_info` column was missing, causing data to not persist. This PR adds the column to the initial database schema and ensures its presence idempotently on server startup.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe742841-537e-433e-a8b7-2d9fa6519882">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fe742841-537e-433e-a8b7-2d9fa6519882">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

