### PR TITLE
Fix kanka's reported error

### DIFF
--- a/script.js
+++ b/script.js
@@ -304,6 +304,16 @@ class VIPService {
                     // JSON parse hatası durumunda status code kullan
                     console.warn('JSON parse hatası, status code kullanılıyor:', parseError);
                 }
+
+                // Yetkisiz/Geçersiz oturum durumlarını kullanıcı dostu şekilde ele al
+                if (response.status === 401 || response.status === 403) {
+                    console.warn('⚠️ Yetkilendirme hatası:', response.status, errorMessage);
+                    try { this.clearAuthData(); } catch (_) {}
+                    try { this.hideMainContent && this.hideMainContent(); } catch (_) {}
+                    try { this.showLoginModal && this.showLoginModal(); } catch (_) {}
+                    try { this.showNotification && this.showNotification('Oturumunuz sona erdi. Lütfen tekrar giriş yapın.', 'error'); } catch (_) {}
+                }
+
                 throw new Error(errorMessage);
             }
 
@@ -562,7 +572,8 @@ class VIPService {
             this.renderGuests();
             this.updateGuestCount();
         } catch (error) {
-            this.showNotification('Misafirler yüklenirken hata oluştu!', 'error');
+            console.error('❌ Misafirler yüklenirken hata:', error);
+            this.showNotification(error.message || 'Misafirler yüklenirken hata oluştu!', 'error');
         }
     }
 


### PR DESCRIPTION
Handle expired/invalid tokens and show specific error messages when loading guests fails.

The previous generic error message for guest loading was unhelpful, especially for 401/403 authorization issues. This change provides a clear message ("Oturumunuz sona erdi. Lütfen tekrar giriş yapın.") and prompts re-login, addressing the user's reported error.

---
<a href="https://cursor.com/background-agent?bcId=bc-8247a727-48bc-47e1-9bb3-eae04900d932">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8247a727-48bc-47e1-9bb3-eae04900d932">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

